### PR TITLE
simplify circleci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 jobs:
-  build:
+  build-and-test:
     docker:
       - image: ubuntu:21.10
     steps:
@@ -12,29 +12,9 @@ jobs:
       - run: sudo apt install -y make
       - checkout
       - run: make install
-      # Save workspace for subsequent jobs (i.e. test)
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-  test:
-    docker:
-      - image: ubuntu:21.10
-    steps:
-      # install sudo and bash: https://github.com/dwyl/learn-circleci/issues/12
-      - run: apt update && apt install -y sudo
-      - run: ls -al /bin/sh && sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh && ls -al /bin/sh
-
-      # Reuse the workspace from the build job
-      - attach_workspace:
-          at: .
-      - run: sudo apt install -y make file shellcheck
       - run: make test
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
-      - test:
-          requires:
-            - build
+      - build-and-test


### PR DESCRIPTION
I want the tests to run in the same environment as we install into with
`install-packages.sh`. I didn't want to fight with CircleCI anymore
figuring out how to do that, I'll just make everything a single step.