### PR TITLE
Keep existing .gitconfig for gitpod

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,4 +24,4 @@ make
 echo Finished stow at "$(date)"
 
 echo concatenating ~/.gitconfig together
-cat ~/.gitconfig.gitpod >> ~/.gitconfig
+cat ~/.gitconfig.gitpod >>~/.gitconfig

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,14 +10,10 @@ echo Installing fast packages at "$(date)"
 make install-fast-packages
 echo Finished installing fast packages at "$(date)"
 
-# gitpod provides a garbage ~/.zshrc file
-echo removing ~/.zshrc
-cat ~/.zshrc
-rm ~/.zshrc
-
 # gitpod stores git credentials in .gitconfig. we need those! save them and add
-# them back in later
+# them back in later. same for .zshrc settings
 mv ~/.gitconfig ~/.gitconfig.gitpod
+mv ~/.zshrc ~/.zshrc.gitpod
 
 echo Running stow at "$(date)"
 make
@@ -25,3 +21,5 @@ echo Finished stow at "$(date)"
 
 echo concatenating ~/.gitconfig together
 cat ~/.gitconfig.gitpod >> ~/.gitconfig
+echo concatenating ~/.zshrc together
+cat ~/.zshrc.gitpod >> ~/.zshrc

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,10 +10,14 @@ echo Installing fast packages at "$(date)"
 make install-fast-packages
 echo Finished installing fast packages at "$(date)"
 
+# gitpod provides a garbage ~/.zshrc file
+echo removing ~/.zshrc
+cat ~/.zshrc
+rm ~/.zshrc
+
 # gitpod stores git credentials in .gitconfig. we need those! save them and add
-# them back in later. same for .zshrc settings
+# them back in later
 mv ~/.gitconfig ~/.gitconfig.gitpod
-mv ~/.zshrc ~/.zshrc.gitpod
 
 echo Running stow at "$(date)"
 make
@@ -21,5 +25,3 @@ echo Finished stow at "$(date)"
 
 echo concatenating ~/.gitconfig together
 cat ~/.gitconfig.gitpod >> ~/.gitconfig
-echo concatenating ~/.zshrc together
-cat ~/.zshrc.gitpod >> ~/.zshrc

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,14 +10,18 @@ echo Installing fast packages at "$(date)"
 make install-fast-packages
 echo Finished installing fast packages at "$(date)"
 
-# gitpod provides garbage ~/.zshrc and .gitconfig files
+# gitpod provides a garbage ~/.zshrc file
 echo removing ~/.zshrc
 cat ~/.zshrc
 rm ~/.zshrc
-echo removing ~/.gitconfig
-cat ~/.gitconfig
-rm ~/.gitconfig
+
+# gitpod stores git credentials in .gitconfig. we need those! save them and add
+# them back in later
+mv ~/.gitconfig ~/.gitconfig.gitpod
 
 echo Running stow at "$(date)"
 make
 echo Finished stow at "$(date)"
+
+echo concatenating ~/.gitconfig together
+cat ~/.gitconfig.gitpod >> ~/.gitconfig

--- a/files/.gitconfig
+++ b/files/.gitconfig
@@ -101,5 +101,12 @@ applied = cyan_foreground
 current = green_foreground
 unapplied = white_foreground
 hidden = red_foreground
+<<<<<<< HEAD
 [credential]
 helper = /usr/bin/gp credential-helper
+||||||| a84e417 (Gitpod credential helper (#71))
+
+[credential]
+	helper = /usr/bin/gp credential-helper
+=======
+>>>>>>> parent of a84e417 (Gitpod credential helper (#71))

--- a/files/.gitconfig
+++ b/files/.gitconfig
@@ -101,12 +101,3 @@ applied = cyan_foreground
 current = green_foreground
 unapplied = white_foreground
 hidden = red_foreground
-<<<<<<< HEAD
-[credential]
-helper = /usr/bin/gp credential-helper
-||||||| a84e417 (Gitpod credential helper (#71))
-
-[credential]
-	helper = /usr/bin/gp credential-helper
-=======
->>>>>>> parent of a84e417 (Gitpod credential helper (#71))


### PR DESCRIPTION
The existing .gitconfig from gitpod includes some required values for our
work repo.
Keep around the .gitconfig from Gitpod by concatenating them together.