### PR TITLE
Switch to dotfiles repo only if needed

### DIFF
--- a/start-tmux-and-install-slow-packages.sh
+++ b/start-tmux-and-install-slow-packages.sh
@@ -6,7 +6,12 @@ echo "{\"authToken\": \"$GRAPHITE_AUTH_TOKEN\"}" >~/.graphite_user_config
 
 # start tmux session, with background windows doing setup
 tmux new-session -d -s work
-tmux new-window -n install-slow 'cd ~/.dotfiles && make install-slow-packages && pre-commit install --install-hooks'
+if [[ -d /workspace/dotfiles ]]; then
+    tmux new-window -n install-slow 'cd /workspace/dotfiles && make install-slow-packages && pre-commit install --install-hooks'
+else
+    # if we're not already in a dotfiles repo, find one
+    tmux new-window -n install-slow 'cd ~/.dotfiles && make install-slow-packages && pre-commit install --install-hooks'
+fi
 tmux select-window -t 1
 
 # connect to tmux session

--- a/start-tmux-and-install-slow-packages.sh
+++ b/start-tmux-and-install-slow-packages.sh
@@ -7,10 +7,10 @@ echo "{\"authToken\": \"$GRAPHITE_AUTH_TOKEN\"}" >~/.graphite_user_config
 # start tmux session, with background windows doing setup
 tmux new-session -d -s work
 if [[ -d /workspace/dotfiles ]]; then
-    tmux new-window -n install-slow 'cd /workspace/dotfiles && make install-slow-packages && pre-commit install --install-hooks'
+	tmux new-window -n install-slow 'cd /workspace/dotfiles && make install-slow-packages && pre-commit install --install-hooks'
 else
-    # if we're not already in a dotfiles repo, find one
-    tmux new-window -n install-slow 'cd ~/.dotfiles && make install-slow-packages && pre-commit install --install-hooks'
+	# if we're not already in a dotfiles repo, find one
+	tmux new-window -n install-slow 'cd ~/.dotfiles && make install-slow-packages && pre-commit install --install-hooks'
 fi
 tmux select-window -t 1
 


### PR DESCRIPTION
We're running into an issue on our dotfiles repo where we're installing
older versions of the scripts. Use the latest version available!