### PR TITLE
gitconfig: remove /home/topher hardcoded paths

### DIFF
--- a/files/.gitconfig
+++ b/files/.gitconfig
@@ -64,12 +64,12 @@ name = Topher Brown
 email = topher@memfault.com
 [commit]
 verbose = 1
-template = /home/topher/.memfault-git-commit-template
+template = $HOME/.memfault-git-commit-template
 
 [core]
 editor = vim
 bare = false
-excludesFile = /home/topher/.gitignore_global
+excludesFile = $HOME/.gitignore_global
 
 [diff]
 tool = nvimdiff


### PR DESCRIPTION
We were running into issues where the .gitconfig template was not being
found correctly, which led to errors when committing.

 ### Test plan
Running `git commit` should now work without error.