### PR TITLE
Remove mouse scrolling in scrollback buffer

### DIFF
--- a/files/.tmux.conf
+++ b/files/.tmux.conf
@@ -30,8 +30,6 @@ set-window-option -g automatic-rename on
 set-option -g window-status-current-style fg=black,bg=white
 # increase scrollback lines
 set-option -g history-limit 50000
-# mouse scrolls scrollback buffer
-set-option -g mouse on
 # status bar settings (utf8, message display time[ms], update interval)
 set-option -g status-interval 5
 set-option -g display-time 4000


### PR DESCRIPTION
This was mostly a good change, but it breaks copying in gitpod. Let's just
remove it for now.