### PR TITLE
make always returns "true"

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,7 +13,7 @@ elif [[ -d "/home/gitpod/.dotfiles" ]]; then
 fi
 
 echo Installing fast packages at "$(date)"
-make install-fast-packages
+make install-fast-packages || true
 echo Finished installing fast packages at "$(date)"
 
 # gitpod provides a garbage ~/.zshrc file


### PR DESCRIPTION
We're running into issues where Gitpod seems to be stopping the build after running the make command. Let's make it unambiguous that we want to keep going after `make`!