### PR TITLE
Add kitty xterm package

### DIFF
--- a/scripts/install-slow-packages.sh
+++ b/scripts/install-slow-packages.sh
@@ -23,6 +23,7 @@ sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
 	gron \
 	htop \
 	httpie \
+	kitty-terminfo \
 	moreutils \
 	neovim \
 	jq \


### PR DESCRIPTION
Without this, when we ssh into tmux things go wonky.

Docs link: https://sw.kovidgoyal.net/kitty/faq/#i-get-errors-about-the-terminal-being-unknown-or-opening-the-terminal-failing-or-functional-keys-like-arrow-keys-don-t-work