### PR TITLE
do not install nvim copilot anymore

### DIFF
--- a/update_external_dependencies.sh
+++ b/update_external_dependencies.sh
@@ -44,16 +44,6 @@ git clone https://github.com/jeffreytse/zsh-vi-mode files/zsh-custom/plugins/zsh
 rm -rf files/zsh-custom/plugins/zsh-vi-mode.git
 echo 'done upgrading zsh-vi-mode'
 
-# copilot for neovim.
-# https://github.com/github/copilot.vim
-# run ':Copilot setup' in neovim
-echo 'upgrading copilot.vim'
-rm -rf files/.config/nvim/pack/github/start/copilot.vim/.git
-rm -r files/.config/nvim/pack/github/start/copilot.vim
-git clone https://github.com/github/copilot.vim.git files/.config/nvim/pack/github/start/copilot.vim
-rm -rf files/.config/nvim/pack/github/start/copilot.vim/.git
-echo 'done upgrading copilot.vim'
-
 # https://github.com/binpash/try
 echo 'updating try script'
 rm -rf files/bin/try


### PR DESCRIPTION
It does not work without node, and I don't want to install global node
with this script anymore.